### PR TITLE
Update twitter/x handle

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -191,7 +191,7 @@ const config = {
               },
               {
                 label: "Twitter",
-                href: "https://twitter.com/flydehq",
+                href: "https://twitter.com/FlydeDev",
               },
             ],
           },


### PR DESCRIPTION
docusauros.config has the old (flydehq) handle
updated to new (FlydeDev)