### PR TITLE
resolving of ui bundle missed path by 1 level #120

### DIFF
--- a/examples/custom-macro-nodes/src/Duplicate/Duplicate.flyde.ts
+++ b/examples/custom-macro-nodes/src/Duplicate/Duplicate.flyde.ts
@@ -37,7 +37,7 @@ const node: MacroNode<number> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/Duplicate.js",
+    editorComponentBundlePath: "../../dist/Duplicate.js",
   },
   defaultData: 2,
 };

--- a/examples/custom-macro-nodes/src/InlineValue/InlineValue.flyde.ts
+++ b/examples/custom-macro-nodes/src/InlineValue/InlineValue.flyde.ts
@@ -21,7 +21,7 @@ const node: MacroNode<any> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/InlineValue.js",
+    editorComponentBundlePath: "../../dist/InlineValue.js",
   },
   defaultData: "",
 };

--- a/examples/dad-jokes-cli/src/macro-node-simple/Duplicate.flyde.ts
+++ b/examples/dad-jokes-cli/src/macro-node-simple/Duplicate.flyde.ts
@@ -37,7 +37,7 @@ const node: MacroNode<number> = {
   displayNameBuilder: (times) => `Duplicate x ${times}`,
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/Duplicate.js",
+    editorComponentBundlePath: "../../dist/Duplicate.js",
   },
   defaultData: 2,
 };

--- a/examples/dad-jokes-cli/src/macro-node-simple/InlineValue.flyde.ts
+++ b/examples/dad-jokes-cli/src/macro-node-simple/InlineValue.flyde.ts
@@ -21,7 +21,7 @@ const node: MacroNode<any> = {
   displayNameBuilder: () => `Emit Value`,
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/InlineValue.js",
+    editorComponentBundlePath: "../../dist/InlineValue.js",
   },
   defaultData: "",
 };

--- a/resolver/src/resolver/resolve-dependencies/macro-node-to-definition.ts
+++ b/resolver/src/resolver/resolve-dependencies/macro-node-to-definition.ts
@@ -21,14 +21,12 @@ export function macroNodeToDefinition<T>(
       editorComponentBundleContent: "",
     } as MacroEditorConfigCustomDefinition,
   };
-  const BundlePathPlusOne = join(
+  let editorComponentPath = join(
+    importPath,
     "..",
     macro.editorConfig.editorComponentBundlePath,
   );
-  let editorComponentPath = join(
-    importPath,
-    BundlePathPlusOne,
-  );
+  // fallback for backwards compatibility (see issue #120)
   if (!existsSync(editorComponentPath)) {
     editorComponentPath = join(
       importPath,

--- a/resolver/src/resolver/resolve-dependencies/macro-node-to-definition.ts
+++ b/resolver/src/resolver/resolve-dependencies/macro-node-to-definition.ts
@@ -3,7 +3,7 @@ import {
   MacroNode,
   MacroNodeDefinition,
 } from "@flyde/core";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 
 export function macroNodeToDefinition<T>(
@@ -21,11 +21,20 @@ export function macroNodeToDefinition<T>(
       editorComponentBundleContent: "",
     } as MacroEditorConfigCustomDefinition,
   };
-  const editorComponentPath = join(
-    importPath,
+  const BundlePathPlusOne = join(
     "..",
     macro.editorConfig.editorComponentBundlePath,
   );
+  let editorComponentPath = join(
+    importPath,
+    BundlePathPlusOne,
+  );
+  if (!existsSync(editorComponentPath)) {
+    editorComponentPath = join(
+      importPath,
+      macro.editorConfig.editorComponentBundlePath,
+    )
+  }
 
   try {
     const content = readFileSync(editorComponentPath, "utf8");

--- a/resolver/src/resolver/resolve-dependencies/macro-node-to-definition.ts
+++ b/resolver/src/resolver/resolve-dependencies/macro-node-to-definition.ts
@@ -23,7 +23,8 @@ export function macroNodeToDefinition<T>(
   };
   const editorComponentPath = join(
     importPath,
-    macro.editorConfig.editorComponentBundlePath
+    "..",
+    macro.editorConfig.editorComponentBundlePath,
   );
 
   try {

--- a/stdlib/src/ControlFlow/Conditional.flyde.ts
+++ b/stdlib/src/ControlFlow/Conditional.flyde.ts
@@ -29,14 +29,14 @@ export interface ConditionalConfig {
   propertyPath: string;
   condition: { type: ConditionType; data?: string };
   compareTo:
-    | { mode: "static"; value: any; type: "number" | "string" | "json" }
-    | { mode: "dynamic"; propertyPath: string };
+  | { mode: "static"; value: any; type: "number" | "string" | "json" }
+  | { mode: "dynamic"; propertyPath: string };
   trueValue:
-    | { type: "value" | "compareTo" }
-    | { type: "expression"; data: string };
+  | { type: "value" | "compareTo" }
+  | { type: "expression"; data: string };
   falseValue:
-    | { type: "value" | "compareTo" }
-    | { type: "expression"; data: string };
+  | { type: "value" | "compareTo" }
+  | { type: "expression"; data: string };
 }
 
 function conditionalConfigToDisplayName(config: ConditionalConfig) {
@@ -185,7 +185,7 @@ export const Conditional: MacroNode<ConditionalConfig> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/ui/Conditional.js",
+    editorComponentBundlePath: "../../dist/ui/Conditional.js",
   },
 };
 

--- a/stdlib/src/ControlFlow/Switch.flyde.ts
+++ b/stdlib/src/ControlFlow/Switch.flyde.ts
@@ -8,13 +8,13 @@ export interface SwitchConfig {
     outputExpression: string;
   }[];
   defaultCase:
-    | {
-        enabled: true;
-        outputExpression: string;
-      }
-    | {
-        enabled: false;
-      };
+  | {
+    enabled: true;
+    outputExpression: string;
+  }
+  | {
+    enabled: false;
+  };
 }
 
 export const Switch: MacroNode<SwitchConfig> = {
@@ -108,6 +108,6 @@ export const Switch: MacroNode<SwitchConfig> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/ui/Switch.js",
+    editorComponentBundlePath: "../../dist/ui/Switch.js",
   },
 };

--- a/stdlib/src/Lists/Collect/Collect.flyde.ts
+++ b/stdlib/src/Lists/Collect/Collect.flyde.ts
@@ -138,6 +138,6 @@ export const Collect: MacroNode<CollectConfig> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../../dist/ui/Collect.js",
+    editorComponentBundlePath: "../../../dist/ui/Collect.js",
   },
 };

--- a/stdlib/src/Values/CodeExpression.flyde.ts
+++ b/stdlib/src/Values/CodeExpression.flyde.ts
@@ -47,6 +47,6 @@ export const CodeExpression: MacroNode<CodeExpressionConfig> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/ui/CodeExpression.js",
+    editorComponentBundlePath: "../../dist/ui/CodeExpression.js",
   },
 };

--- a/stdlib/src/Values/InlineValue.flyde.ts
+++ b/stdlib/src/Values/InlineValue.flyde.ts
@@ -42,6 +42,6 @@ export const InlineValue: MacroNode<InlineValueConfig> = {
   },
   editorConfig: {
     type: "custom",
-    editorComponentBundlePath: "../../../dist/ui/InlineValue.js",
+    editorComponentBundlePath: "../../dist/ui/InlineValue.js",
   },
 };


### PR DESCRIPTION
### New breaking change here

- **Who does this affect**:
Their are using Macro Editor.

- **How to migrate**:
Change way to specify path to Macro Editor bundle path.
Directory one up.

　　　ditorComponentBundlePath: "../../../macro.tsx" → ditorComponentBundlePath: "../../macro.tsx"

- **Why make this breaking change**:
We changed it to the one that most people expect as a behavior.

- **Severity (number of people affected x effort)**:
Undocumented and few users are expected.
The response is simply to replace the letters.
Therefore, the impact is low.