### PR TITLE
Fixes comment node lighting up when flow runs

### DIFF
--- a/flow-editor/src/visual-node-editor/instance-view/style.scss
+++ b/flow-editor/src/visual-node-editor/instance-view/style.scss
@@ -37,8 +37,8 @@ $half-of-pin-height: 16px;
   z-index: 1;
 
   &[data-node-id="Comment"] {
-    [data-pin-id="__trigger"] {
-      display: none; // mega ugly hack to hide the trigger pin on the comment node
+    [data-pin-id] {
+      display: none; // mega ugly hack to hide pins on comment node
     }
   }
 

--- a/stdlib/src/Misc/Comment.flyde.ts
+++ b/stdlib/src/Misc/Comment.flyde.ts
@@ -1,4 +1,4 @@
-import { MacroNode } from "@flyde/core";
+import { MacroNode, nodeInput } from "@flyde/core";
 
 export interface CommentConfig {
   content: string;
@@ -34,7 +34,9 @@ export const Comment: MacroNode<CommentConfig> = {
 
       displayName: config.content,
       description: "Comment node",
-      inputs: {},
+      inputs: {
+        never: nodeInput(), // this is a hack to make the node never trigger
+      },
       outputs: {},
     };
   },


### PR DESCRIPTION
Very hackysh workaround due to the fact that the comment node was implemented 100% via user-world