### PR TITLE
fix: Pins and dragging improvements

### DIFF
--- a/flow-editor/src/visual-node-editor/pin-view/PinView.tsx
+++ b/flow-editor/src/visual-node-editor/pin-view/PinView.tsx
@@ -287,7 +287,9 @@ export const PinView: React.FC<PinViewProps> = React.memo(function PinView(
         }}
         onMouseUp={_onMouseUp}
         onClick={onPinHandleClick}
-      />
+      >
+        <div className={classNames("pin-handle-inner", type )} />
+      </div>
     </div>
   );
 });

--- a/flow-editor/src/visual-node-editor/pin-view/PinView.tsx
+++ b/flow-editor/src/visual-node-editor/pin-view/PinView.tsx
@@ -288,7 +288,7 @@ export const PinView: React.FC<PinViewProps> = React.memo(function PinView(
         onMouseUp={_onMouseUp}
         onClick={onPinHandleClick}
       >
-        <div className={classNames("pin-handle-inner", type )} />
+        <div className={classNames("pin-handle-inner", type, { dark } )} />
       </div>
     </div>
   );

--- a/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
+++ b/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
@@ -3,7 +3,7 @@ $dark-pin-text: #fff;
 $light-pin-text: #333;
 $dark-pin-handle-border: #aaaaaa;
 $light-pin-handle-border: #666666;
-$pin-highlight: rgba(40, 135, 244, 1);
+$pin-highlight: #2887f4;
 
 .pin {
   cursor: pointer;
@@ -52,7 +52,7 @@ $pin-highlight: rgba(40, 135, 244, 1);
 .pin-handle {
   position: absolute;
   top: 50%;
-  width: 32px;
+  width: 64px;
   height: 32px;
   transform: translateY(-50%);
   border-radius: 50%;
@@ -115,14 +115,14 @@ $pin-highlight: rgba(40, 135, 244, 1);
     }
 
     &::before {
-      width: 16px;
-      height: 16px;
+      width: 12px;
+      height: 12px;
       border: 1px solid rgba(255, 255, 255, 0.5);
     }
 
     &::after {
-      width: 24px;
-      height: 24px;
+      width: 16px;
+      height: 16px;
       border: 1px solid rgba(255, 255, 255, 0.2);
     }
 

--- a/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
+++ b/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
@@ -17,6 +17,7 @@ $pin-highlight: rgba(40, 135, 244, 1);
     display: inline-block;
     vertical-align: middle;
     padding-bottom: 2px;
+    font-size: 12px;
   }
 
   .size-wide & .pin-inner {

--- a/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
+++ b/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
@@ -1,7 +1,7 @@
 // Theme colors
 $dark-pin-text: #fff;
 $light-pin-text: #333;
-$dark-pin-handle-border: #aaaaaa;
+$dark-pin-handle-border: #cccccc;
 $light-pin-handle-border: #666666;
 $pin-highlight: #2887f4;
 
@@ -117,13 +117,28 @@ $pin-highlight: #2887f4;
     &::before {
       width: 12px;
       height: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.5);
     }
 
     &::after {
       width: 16px;
       height: 16px;
+    }
+
+    // Theme-based ring border colors
+    &.dark::before {
+      border: 1px solid rgba(255, 255, 255, 0.5);
+    }
+
+    &.dark::after {
       border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    &:not(.dark)::before {
+      border: 1px solid rgba(0, 0, 0, 0.2);
+    }
+
+    &:not(.dark)::after {
+      border: 1px solid rgba(0, 0, 0, 0.1);
     }
 
     // Semi-circle masks for outer rings

--- a/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
+++ b/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
@@ -3,6 +3,7 @@ $dark-pin-text: #fff;
 $light-pin-text: #333;
 $dark-pin-handle-border: #aaaaaa;
 $light-pin-handle-border: #666666;
+$pin-highlight: rgba(40, 135, 244, 1);
 
 .pin {
   cursor: pointer;
@@ -14,6 +15,8 @@ $light-pin-handle-border: #666666;
     text-overflow: ellipsis;
     white-space: nowrap;
     display: inline-block;
+    vertical-align: middle;
+    padding-bottom: 2px;
   }
 
   .size-wide & .pin-inner {
@@ -47,35 +50,94 @@ $light-pin-handle-border: #666666;
 
 .pin-handle {
   position: absolute;
-  z-index: -1;
-  box-sizing: border-box;
-  position: absolute;
-  width: 8px;
-  height: 8px;
   top: 50%;
+  width: 32px;
+  height: 32px;
+  transform: translateY(-50%);
   border-radius: 50%;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   transition: width 0.15s ease-out, height 0.15s ease-out,
     transform 0.15s ease-out;
 
-  &.dark {
-    background: #ffffff;
-    border: 1px solid $dark-pin-handle-border;
+  // Input & Output position and masks
+  &.input {
+    left: -16px;
+    mask-image: linear-gradient(to right, black 50%, transparent 50%);
   }
 
-  &:not(.dark) {
-    background: #ffffff;
-    border: 1px solid $light-pin-handle-border;
+  &.output {
+    right: -16px;
+    mask-image: linear-gradient(to left, black 50%, transparent 50%);
   }
 
-  &::before {
-    content: "";
-    position: absolute;
-    width: 30px;
-    height: 30px;
-    top: 50%;
+  mask-size: 100% 100%;
+  mask-repeat: no-repeat;
+
+  // Highlight outer rings
+  &.closest::before,
+  &:hover::before {
+    opacity: 1;
+  }
+
+  .pin-handle-inner {
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
-    transform: translate(-50%, -50%);
-    z-index: -1;
+    position: relative;
+    transition: all 0.15s ease-out;
+
+    // Theme colors
+    &.dark {
+      background: #ffffff;
+      border: 1px solid $dark-pin-handle-border;
+    }
+
+    &:not(.dark) {
+      background: #ffffff;
+      border: 1px solid $light-pin-handle-border;
+    }
+
+    // Outer rings
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      border-radius: 50%;
+      opacity: 0;
+      transition: opacity 0.15s ease-out, transform 0.15s ease-out;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    &::before {
+      width: 16px;
+      height: 16px;
+      border: 1px solid rgba(255, 255, 255, 0.5);
+    }
+
+    &::after {
+      width: 24px;
+      height: 24px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    // Semi-circle masks for outer rings
+    &.input::before,
+    &.input::after {
+      mask-image: linear-gradient(to right, black 50%, transparent 50%);
+    }
+
+    &.output::before,
+    &.output::after {
+      mask-image: linear-gradient(to left, black 50%, transparent 50%);
+    }
+
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
   }
 
   &.input {
@@ -95,25 +157,17 @@ $light-pin-handle-border: #666666;
     }
   }
 
-  &:hover,
-  &.closest {
-    width: 13px;
-    height: 13px;
-
-    &.input {
-      left: -1px;
-    }
-
-    &.output {
-      right: -1px;
-    }
+  // Hover/closest state ring animation and color shift
+  &:hover .pin-handle-inner,
+  &.selected .pin-handle-inner {
+    background: $pin-highlight;
   }
 
-  &:hover {
-    background: rgb(128, 187, 255);
-  }
-
-  &.selected {
-    background: rgba(40, 135, 244, 1);
+  // Ring opacity on interaction
+  &.closest .pin-handle-inner::before,
+  &:hover .pin-handle-inner::before,
+  &.closest .pin-handle-inner::after,
+  &:hover .pin-handle-inner::after {
+    opacity: 1;
   }
 }


### PR DESCRIPTION
/claim #218 
Fixes #218

Changes:
- Implemented a new design for hover and proximity states for the pin-handles.
- Improved the connection creation process by expanding the drag-and-drop area around pin-handles, making it easier and user-friendly.
- Aligned all pin-handles precisely to the center of their respective pins.
- Ensured label consistency by setting a fixed font size for the `.pin-inner` class.

Video:

https://github.com/user-attachments/assets/c4437057-f0ea-426a-8ff2-5318d08dc254

