### PR TITLE
fix: Broken Inspect Pin by Hover

### DIFF
--- a/flow-editor/src/visual-node-editor/VisualNodeEditor.tsx
+++ b/flow-editor/src/visual-node-editor/VisualNodeEditor.tsx
@@ -1378,6 +1378,7 @@ export const VisualNodeEditor: React.FC<VisualNodeEditorProps & { ref?: any }> =
             <ContextMenuTrigger
               className={classNames("visual-node-editor", props.className, {
                 dark: darkMode,
+                dragged: draggedConnection !== null,
               })}
               data-id={node.id}
               disabled={!isBoardInFocus.current}

--- a/flow-editor/src/visual-node-editor/VisualNodeEditor.tsx
+++ b/flow-editor/src/visual-node-editor/VisualNodeEditor.tsx
@@ -1378,7 +1378,7 @@ export const VisualNodeEditor: React.FC<VisualNodeEditorProps & { ref?: any }> =
             <ContextMenuTrigger
               className={classNames("visual-node-editor", props.className, {
                 dark: darkMode,
-                dragged: draggedConnection !== null,
+                "node-dragged": draggedConnection !== null,
               })}
               data-id={node.id}
               disabled={!isBoardInFocus.current}

--- a/flow-editor/src/visual-node-editor/VisualNodeEditor.tsx
+++ b/flow-editor/src/visual-node-editor/VisualNodeEditor.tsx
@@ -6,7 +6,6 @@ import {
   isCodeNodeInstance,
   ConnectionData,
   isInternalConnectionNode,
-  VisualNode,
   NodeInstance,
   PinType,
   isVisualNode,
@@ -23,7 +22,6 @@ import {
   EditorVisualNode,
   EditorNodeInstance,
   FlydeFlow,
-  CodeNodeInstance,
   isVisualNodeInstance,
   ImportableEditorNode,
   EditorCodeNodeDefinition,
@@ -730,6 +728,7 @@ export const VisualNodeEditor: React.FC<VisualNodeEditorProps & { ref?: any }> =
             description={v.description ?? ''}
             onMouseUp={onNodeIoMouseUp}
             onMouseDown={onNodeIoMouseDown}
+            increasedDropArea={!!draggedConnection}
           />
         ));
       };
@@ -1377,8 +1376,7 @@ export const VisualNodeEditor: React.FC<VisualNodeEditorProps & { ref?: any }> =
           <ContextMenu>
             <ContextMenuTrigger
               className={classNames("visual-node-editor", props.className, {
-                dark: darkMode,
-                "node-dragged": draggedConnection !== null,
+                dark: darkMode
               })}
               data-id={node.id}
               disabled={!isBoardInFocus.current}
@@ -1452,6 +1450,7 @@ export const VisualNodeEditor: React.FC<VisualNodeEditorProps & { ref?: any }> =
                     onToggleSticky={onToggleSticky}
                     selected={selectedInstances.indexOf(ins.id) !== -1}
                     dragged={draggingId === ins.id}
+                    increasedPinDropArea={!!draggedConnection}
                     onInspectPin={_onInspectPin}
                     selectedInput={
                       to && isInternalConnectionNode(to) && to.insId === ins.id

--- a/flow-editor/src/visual-node-editor/instance-view/InstanceView.tsx
+++ b/flow-editor/src/visual-node-editor/instance-view/InstanceView.tsx
@@ -160,6 +160,8 @@ export interface InstanceViewProps {
 
   isConnectedInstanceSelected: boolean;
 
+  increasedPinDropArea?: boolean;
+
   inlineGroupProps?: VisualNodeEditorProps & VisualNodeEditorContextType;
   onCloseInlineEditor: () => void;
 
@@ -657,6 +659,7 @@ export const InstanceView: React.FC<InstanceViewProps> =
                 optional={optionalInputs.has(k)}
                 connected={connectedInputs.has(k)}
                 isSticky={stickyInputs[k] ?? false}
+                increasedDropArea={props.increasedPinDropArea}
                 // minimized={!selected}
                 onToggleSticky={_onToggleSticky}
                 selected={k === selectedInput}
@@ -694,6 +697,7 @@ export const InstanceView: React.FC<InstanceViewProps> =
                 currentInsId={instance.id}
                 ancestorsInsIds={props.ancestorsInsIds}
                 connected={connectedOutputs.has(k)}
+                increasedDropArea={props.increasedPinDropArea}
                 type="output"
                 id={k}
                 // minimized={selected ? false : outputsToRender.length === 1}

--- a/flow-editor/src/visual-node-editor/node-io-view/NodeIoView.tsx
+++ b/flow-editor/src/visual-node-editor/node-io-view/NodeIoView.tsx
@@ -25,6 +25,7 @@ export interface NodeIoViewProps {
   inputMode?: InputMode;
   closest: boolean;
   viewPort: { pos: Pos; zoom: number };
+  increasedDropArea?: boolean;
   onDblClick?: (pinId: string, e: React.MouseEvent) => void;
   onDelete?: (type: PinType, pin: string) => void;
   onRename?: (type: PinType, pin: string) => void;
@@ -240,6 +241,7 @@ export const NodeIoView: React.FC<NodeIoViewProps> = React.memo(
             onToggleBreakpoint={noop}
             onInspect={noop}
             description={description}
+            increasedDropArea={props.increasedDropArea}
             onMouseUp={(pinId, pinType, e) => {
               e.stopPropagation();
               _onMouseUp(e);
@@ -265,6 +267,7 @@ export const NodeIoView: React.FC<NodeIoViewProps> = React.memo(
             onToggleBreakpoint={noop}
             onInspect={noop}
             description={description}
+            increasedDropArea={props.increasedDropArea}
             onMouseUp={(pinId, pinType, e) => {
               e.stopPropagation();
               _onMouseUp(e);

--- a/flow-editor/src/visual-node-editor/pin-view/PinView.tsx
+++ b/flow-editor/src/visual-node-editor/pin-view/PinView.tsx
@@ -49,6 +49,7 @@ export type PinViewProps = {
   ancestorsInsIds?: string;
   selected: boolean;
   connected: boolean;
+  increasedDropArea?: boolean;
   onDoubleClick?: (id: string, e: React.MouseEvent) => void;
   onShiftClick?: (id: string, e: React.MouseEvent) => void;
   onClick: (id: string, type: PinType, e: React.MouseEvent) => void;
@@ -57,7 +58,6 @@ export type PinViewProps = {
   onToggleLogged: (insId: string, pinId: string, type: PinType) => void;
   onToggleBreakpoint: (insId: string, pinId: string, type: PinType) => void;
   onInspect: (insId: string, pin: { id: string; type: PinType }) => void;
-
   onMouseUp: (id: string, type: PinType, e: React.MouseEvent) => void;
   onMouseDown: (id: string, type: PinType, e: React.MouseEvent) => void;
   isMain: boolean;
@@ -172,6 +172,7 @@ export const PinView: React.FC<PinViewProps> = React.memo(function PinView(
         "pin",
         {
           selected,
+          "increased-drop-area": props.increasedDropArea,
           closest: isClosestToMouse,
           optional,
           connected,
@@ -185,6 +186,7 @@ export const PinView: React.FC<PinViewProps> = React.memo(function PinView(
         {
           selected,
           connected,
+          "increased-drop-area": props.increasedDropArea,
           closest: isClosestToMouse,
           optional,
           "error-pin": id === ERROR_PIN_ID,
@@ -288,7 +290,7 @@ export const PinView: React.FC<PinViewProps> = React.memo(function PinView(
         onMouseUp={_onMouseUp}
         onClick={onPinHandleClick}
       >
-        <div className={classNames("pin-handle-inner", type, { dark } )} />
+        <div className={classNames("pin-handle-inner", type, { dark })} />
       </div>
     </div>
   );

--- a/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
+++ b/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
@@ -52,7 +52,7 @@ $pin-highlight: #2887f4;
 .pin-handle {
   position: absolute;
   top: 50%;
-  width: 64px;
+  width: 16px;
   height: 32px;
   transform: translateY(-50%);
   border-radius: 50%;

--- a/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
+++ b/flow-editor/src/visual-node-editor/pin-view/pin-view.scss
@@ -47,6 +47,12 @@ $pin-highlight: #2887f4;
   &:not(.dark) {
     color: $light-pin-text;
   }
+
+  &.increased-drop-area {
+    .pin-handle {
+      width: 64px;
+    }
+  }
 }
 
 .pin-handle {
@@ -159,6 +165,7 @@ $pin-highlight: #2887f4;
   &.input {
     left: -1px;
     transform: translateX(-50%) translateY(-50%);
+
     &::before {
       left: 50%;
     }
@@ -167,6 +174,7 @@ $pin-highlight: #2887f4;
   &.output {
     right: -1px;
     transform: translateX(50%) translateY(-50%);
+
     &::before {
       right: 50%;
       transform: translate(50%, -50%);

--- a/flow-editor/src/visual-node-editor/style.scss
+++ b/flow-editor/src/visual-node-editor/style.scss
@@ -226,4 +226,10 @@
       font-weight: normal;
     }
   }
+
+  &.dragged {
+    .pin-handle {
+      width: 64px;
+    }
+  }
 }

--- a/flow-editor/src/visual-node-editor/style.scss
+++ b/flow-editor/src/visual-node-editor/style.scss
@@ -227,9 +227,4 @@
     }
   }
 
-  &.node-dragged {
-    .pin-handle {
-      width: 64px;
-    }
-  }
 }

--- a/flow-editor/src/visual-node-editor/style.scss
+++ b/flow-editor/src/visual-node-editor/style.scss
@@ -227,7 +227,7 @@
     }
   }
 
-  &.dragged {
+  &.node-dragged {
     .pin-handle {
       width: 64px;
     }


### PR DESCRIPTION
Changes:
- Fixes issue introduced in #222, where pin hover inspection was broken due to `pin-handle` overlapping `pin-inner`.
- Keeps pin-handle small when idle to allow tooltip/hover functionality.
- Maintains large `pin-handle` during drag for smooth interactions.

Video:

https://github.com/user-attachments/assets/27cd814a-7a9b-472b-876a-0c421c893b83



