### PR TITLE
feat: add extensible node discovery with .flyde-nodes.json override

### DIFF
--- a/vscode/src/createNodeFinderWithOverrides.ts
+++ b/vscode/src/createNodeFinderWithOverrides.ts
@@ -1,0 +1,43 @@
+import * as path from "path";
+import * as fs from "fs";
+import { createServerReferencedNodeFinder } from "@flyde/loader";
+import { ReferencedNodeFinder } from "@flyde/loader/dist/resolver/ReferencedNodeFinder";
+import { NodeInstance } from "@flyde/core";
+
+/**
+ * Creates a node finder that checks for .flyde-nodes.json overrides before
+ * falling back to the default server-based node resolution.
+ * 
+ * This allows users to define custom nodes from external runtimes
+ * by placing a .flyde-nodes.json file in the same directory as their flow file.
+ * 
+ * @param flowPath - The full path to the current flow file
+ * @returns A ReferencedNodeFinder function that includes override support
+ */
+export function createNodeFinderWithOverrides(flowPath: string): ReferencedNodeFinder {
+  const baseNodeFinder = createServerReferencedNodeFinder(flowPath);
+  
+  return (instance: NodeInstance) => {
+    // Check if we have a .flyde-nodes.json override in the same directory
+    const overridePath = path.join(path.dirname(flowPath), '.flyde-nodes.json');
+    
+    if (fs.existsSync(overridePath) && instance.source?.type === 'custom') {
+      try {
+        const overrideContent = fs.readFileSync(overridePath, 'utf8');
+        const overrideData = JSON.parse(overrideContent);
+        
+        // Look for node definition in the nodes section
+        if (overrideData.nodes && overrideData.nodes[instance.nodeId]) {
+          const nodeDefinition = overrideData.nodes[instance.nodeId];
+          // Return the editorNode part, which is what resolveEditorNode expects
+          return nodeDefinition.editorNode;
+        }
+      } catch (err) {
+        console.error("Error reading .flyde-nodes.json for node resolution:", err);
+      }
+    }
+    
+    // Fall back to default resolution
+    return baseNodeFinder(instance);
+  };
+}

--- a/vscode/src/test/main.test.ts
+++ b/vscode/src/test/main.test.ts
@@ -82,17 +82,11 @@ suite("Extension Test Suite", () => {
       instance.textContent?.includes("Custom Bob")
     );
     assert(bobExists, "Expected to find 'Custom Bob' instance in the initial flow");
-
-    await delay(5000);
-
     // Click add nodes button to open the menu
     await clickAddNodesButton();
 
     // Get all menu items
     const menuItems = await getMenuItems();
-
-    await delay(5000);
-
     // Check if all custom nodes appear in the menu
     const customBobExists = menuItems.some(item =>
       item.textContent?.includes("Custom Bob")
@@ -120,7 +114,6 @@ suite("Extension Test Suite", () => {
     );
     assert(aliceExists, "Expected to find 'Custom Alice' instance in the canvas after adding it");
 
-    await delay(5000);
   }).retries(3);
 
 

--- a/vscode/src/test/testFileUtils.ts
+++ b/vscode/src/test/testFileUtils.ts
@@ -1,0 +1,62 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+/**
+ * Recursively copies a source file or directory to a destination
+ * @param src - Source path (file or directory)
+ * @param dest - Destination path
+ */
+export function copyRecursive(src: string, dest: string): void {
+  const stats = fs.statSync(src);
+  if (stats.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    fs.readdirSync(src).forEach(childItemName => {
+      copyRecursive(
+        path.join(src, childItemName),
+        path.join(dest, childItemName)
+      );
+    });
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
+/**
+ * Creates a temporary directory with all test fixtures copied
+ * @param fixturesDir - Path to the test fixtures directory
+ * @param templatesDir - Path to the templates directory
+ * @returns Path to the temporary directory
+ */
+export function createTempTestWorkspace(fixturesDir: string, templatesDir: string): string {
+  const tmpDir = path.join(os.tmpdir(), `flyde-test-fixtures-${Date.now()}`);
+
+  if (fs.existsSync(tmpDir)) {
+    throw new Error("Temporary directory already exists");
+  }
+
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  // Copy test fixtures recursively
+  fs.readdirSync(fixturesDir).forEach((file) => {
+    const source = path.join(fixturesDir, file);
+    const dest = path.join(tmpDir, file);
+    copyRecursive(source, dest);
+  });
+
+  // Copy templates
+  fs.readdirSync(templatesDir).forEach((templateFolder) => {
+    // Skip hidden files like .DS_Store
+    if (templateFolder.startsWith('.')) {
+      return;
+    }
+
+    const source = path.join(templatesDir, templateFolder, `Example.flyde`);
+    const dest = path.join(tmpDir, `${templateFolder}.flyde`);
+    if (fs.existsSync(source)) {
+      fs.copyFileSync(source, dest);
+    }
+  });
+
+  return tmpDir;
+}

--- a/vscode/test-fixtures/custom-nodes-override/.flyde-nodes.json
+++ b/vscode/test-fixtures/custom-nodes-override/.flyde-nodes.json
@@ -1,0 +1,104 @@
+{
+  "nodes": {
+    "CustomBob": {
+      "id": "CustomBob",
+      "type": "code",
+      "displayName": "Custom Bob",
+      "description": "A custom external node named Bob",
+      "icon": "fa-solid fa-user",
+      "source": {
+        "type": "custom",
+        "data": "custom://CustomBob"
+      },
+      "editorNode": {
+        "id": "CustomBob",
+        "displayName": "Custom Bob",
+        "description": "A custom external node named Bob",
+        "icon": "fa-solid fa-user",
+        "inputs": {
+          "value": {
+            "description": "Input value to process"
+          }
+        },
+        "outputs": {
+          "result": {
+            "description": "Processed result from external runtime"
+          }
+        },
+        "editorConfig": {
+          "type": "structured"
+        }
+      },
+      "config": {}
+    },
+    "CustomAlice": {
+      "id": "CustomAlice",
+      "type": "code", 
+      "displayName": "Custom Alice",
+      "description": "Another custom external node",
+      "icon": "fa-globe",
+      "source": {
+        "type": "custom",
+        "data": "custom://CustomAlice"
+      },
+      "editorNode": {
+        "id": "CustomAlice",
+        "displayName": "Custom Alice",
+        "description": "Another custom external node",
+        "icon": "fa-globe",
+        "inputs": {
+          "input1": {
+            "description": "First input"
+          },
+          "input2": {
+            "description": "Second input"
+          }
+        },
+        "outputs": {
+          "output": {
+            "description": "Combined output"
+          }
+        },
+        "editorConfig": {
+          "type": "structured"
+        }
+      },
+      "config": {}
+    },
+    "InlineValue": {
+      "id": "InlineValue",
+      "type": "code",
+      "displayName": "Overridden Inline Value",
+      "description": "This overrides the standard InlineValue node",
+      "source": {
+        "type": "package",
+        "data": "@flyde/nodes"
+      },
+      "editorNode": {
+        "id": "InlineValue",
+        "displayName": "Overridden Inline Value",
+        "description": "This overrides the standard InlineValue node",
+        "inputs": {},
+        "outputs": {
+          "value": {
+            "description": "The overridden value"
+          }
+        },
+        "editorConfig": {
+          "type": "structured"
+        }
+      },
+      "config": {}
+    }
+  },
+  "groups": [
+    {
+      "title": "Custom Runtime Nodes",
+      "nodeIds": ["CustomBob", "CustomAlice"]
+    },
+    {
+      "title": "Overridden Stdlib",
+      "nodeIds": ["InlineValue"]
+    }
+  ]
+}

--- a/vscode/test-fixtures/custom-nodes-override/CustomNodesFlow.flyde
+++ b/vscode/test-fixtures/custom-nodes-override/CustomNodesFlow.flyde
@@ -1,0 +1,23 @@
+imports: {}
+node:
+  instances:
+    - pos:
+        x: -195
+        y: 70
+      id: CustomBob-n553n0v3
+      inputConfig: {}
+      nodeId: CustomBob
+      config:
+        value:
+          type: dynamic
+          value: "{{value}}"
+      type: code
+      source:
+        type: custom
+        data: custom://CustomBob
+  connections: []
+  id: CustomNodesFlow
+  inputs: {}
+  outputs: {}
+  inputsPosition: {}
+  outputsPosition: {}


### PR DESCRIPTION
Enables external runtimes to define custom nodes via `.flyde-nodes.json` files.

## Key Features
- Override node palette with custom definitions
- Support custom node resolution during flow rendering
- Clean JSON structure with proper `editorNode` configuration
- Comprehensive test coverage

## Usage
Place a `.flyde-nodes.json` file in the same directory as your flow file to define custom nodes from external runtimes.